### PR TITLE
Avoid erroring out when Link header is not present

### DIFF
--- a/watch-plz
+++ b/watch-plz
@@ -8,6 +8,9 @@ DONT_WATCH = ('lyft/', 'tox-dev/')
 
 
 def _parse_link_header(lnk):
+    if lnk is None:
+        return {}
+
     ret = {}
     parts = lnk.split(',')
     for part in parts:


### PR DESCRIPTION
The `/repositories` and `/subscriptions` GitHub API calls are currently executed through the `_get_all` function. When one of them doesn't include a `Link` header, this is the result:

``` python
Traceback (most recent call last):
  File "./watch-plz", line 69, in <module>
    exit(main())
  File "./watch-plz", line 57, in main
    subbed = {x['full_name'] for x in _get_all('subscriptions', token)}
  File "./watch-plz", line 34, in _get_all
    resp, links = _req(url, headers=headers)
  File "./watch-plz", line 26, in _req
    return json.loads(resp.read()), _parse_link_header(resp.headers['link'])
  File "./watch-plz", line 12, in _parse_link_header
    parts = lnk.split(',')
AttributeError: 'NoneType' object has no attribute 'split'
```

This pull request addresses this issue by simply returning early in the `_parse_link_header` function when the `lnk` parameter is `None`.